### PR TITLE
Fork a pinging thread to ensure browser connections stay alive

### DIFF
--- a/src/PostgRESTWS.hs
+++ b/src/PostgRESTWS.hs
@@ -53,6 +53,8 @@ postgrestWsApp conf refDbStructure pool pqCon =
               -- role claim defaults to anon if not specified in jwt
               -- We should accept only after verifying JWT
               conn <- WS.acceptRequest pendingConn
+              -- Fork a pinging thread to ensure browser connections stay alive
+              WS.forkPingThread conn 30
               -- each websocket needs its own listen connection to avoid
               -- handling of multiple waiting threads in the same connection
               when (hasRead mode) $


### PR DESCRIPTION
**Important Feature Request**

In order to use postgrest-ws with browser applications, it is necessary to fork a pinging thread, otherwise browsers like Chrome, Safari, etc will automatically kill the web socket connection.

Motivation:  I am developing software using Aurelia.  I want to notify my client application when changes occur in certain tables so that the clients can update when necessary without polling for changes.