### PR TITLE
Retry connection

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,7 +8,6 @@ import           Config                               (AppConfig (..),
                                                        prettyVersion,
                                                        readOptions)
 
-import           Data.Function                        (id)
 import           Data.ByteString.Base64               (decode)
 import           Data.String                          (IsString (..))
 import           Data.Text                            (stripPrefix, pack, replace)
@@ -61,8 +60,7 @@ main = do
   getTime <- mkAutoUpdate
     defaultUpdateSettings { updateAction = getPOSIXTime }
 
-  multiOrError <- newHasqlBroadcasterOrError pgSettings
-  let multi = either (panic . show) id multiOrError
+  multi <- newHasqlBroadcaster pgSettings
 
   runSettings appSettings $
     postgrestWsMiddleware (configJwtSecret conf) getTime pool multi $

--- a/postgrest-ws.cabal
+++ b/postgrest-ws.cabal
@@ -1,5 +1,5 @@
 name:                postgrest-ws
-version:             0.3.1.0
+version:             0.3.2.0
 synopsis:            PostgREST extension to map LISTEN/NOTIFY messages to Websockets
 description:         Please see README.md
 homepage:            https://github.com/diogob/postgrest-ws#readme
@@ -44,6 +44,7 @@ library
                      , either
                      , stm-containers
                      , stm
+                     , retry
   default-language:    Haskell2010
   default-extensions: OverloadedStrings, NoImplicitPrelude
 

--- a/src/PostgRESTWS.hs
+++ b/src/PostgRESTWS.hs
@@ -6,6 +6,7 @@
 module PostgRESTWS
   ( postgrestWsMiddleware
   -- * Re-exports
+  , newHasqlBroadcaster
   , newHasqlBroadcasterOrError
   ) where
 
@@ -25,7 +26,7 @@ import qualified Data.ByteString.Lazy           as BL
 import PostgRESTWS.Claims
 import PostgRESTWS.Database
 import PostgRESTWS.Broadcast (Multiplexer, onMessage, readTChan)
-import PostgRESTWS.HasqlBroadcast (newHasqlBroadcasterOrError)
+import PostgRESTWS.HasqlBroadcast (newHasqlBroadcaster, newHasqlBroadcasterOrError)
 import qualified PostgRESTWS.Broadcast as B
 
 data Message = Message

--- a/src/PostgRESTWS/Broadcast.hs
+++ b/src/PostgRESTWS/Broadcast.hs
@@ -25,6 +25,8 @@ import qualified STMContainers.Map as M
 import Control.Concurrent.STM.TChan
 import Control.Concurrent.STM.TQueue
 
+import GHC.Show
+
 data SourceCommands = Open ByteString | Close ByteString deriving (Show)
 data Message = Message { channel :: ByteString
                , payload :: ByteString
@@ -35,6 +37,9 @@ data Multiplexer = Multiplexer { channels :: M.Map ByteString Channel
                                , commands :: TQueue SourceCommands
                                , messages :: TQueue Message
                                }
+
+instance Show Multiplexer where
+  show Multiplexer{} = "Multiplexer"
 
 data Channel = Channel { broadcast :: TChan Message
                        , listeners :: Integer

--- a/test/HasqlBroadcastSpec.hs
+++ b/test/HasqlBroadcastSpec.hs
@@ -22,10 +22,10 @@ spec = describe "newHasqlBroadcaster" $ do
         newConnection connStr =
             either (panic . show) id
             <$> acquire connStr
-            
+
     it "start listening on a database connection as we send an Open command" $ do
       con <- newConnection "postgres://localhost/postgrest_test"
-      multi <- liftIO $ newHasqlBroadcaster con
+      multi <- liftIO $ newHasqlBroadcaster "postgres://localhost/postgrest_test"
 
       atomically $ openChannelProducer multi "test"
 
@@ -36,7 +36,7 @@ spec = describe "newHasqlBroadcaster" $ do
 
     it "stops listening on a database connection as we send a Close command" $ do
       con <- newConnection "postgres://localhost/postgrest_test"
-      multi <- liftIO $ newHasqlBroadcaster con
+      multi <- liftIO $ newHasqlBroadcaster "postgres://localhost/postgrest_test"
 
       atomically $ closeChannelProducer multi "test"
 


### PR DESCRIPTION
Add the `newHasqlBroadcaster` function that will keep trying to connect to the database until it succeeds and build a `HasqlBroadcaster` when the connection becomes available.