### PR TITLE
Use a newtype PgIdentifier to wrap bytestrings that will represent ch…

### DIFF
--- a/postgrest-ws.cabal
+++ b/postgrest-ws.cabal
@@ -45,6 +45,7 @@ library
                      , stm-containers
                      , stm
                      , retry
+                     , stringsearch
   default-language:    Haskell2010
   default-extensions: OverloadedStrings, NoImplicitPrelude
 

--- a/src/PostgRESTWS.hs
+++ b/src/PostgRESTWS.hs
@@ -84,7 +84,7 @@ notifySession :: BS.ByteString
 notifySession channel claimsToSend pool wsCon =
   WS.receiveData wsCon >>= (void . send . jsonMsg)
   where
-    send = notifyPool pool channel
+    send = notifyPool pool $ toPgIdentifier channel
     -- we need to decode the bytestring to re-encode valid JSON for the notification
     jsonMsg = BL.toStrict . A.encode . Message claimsToSend . decodeUtf8With T.lenientDecode
 

--- a/src/PostgRESTWS/Database.hs
+++ b/src/PostgRESTWS/Database.hs
@@ -21,7 +21,7 @@ import qualified Data.ByteString.Char8 as B
 import Data.ByteString.Search (replace)
 newtype Error = NotifyError Text
 
-newtype PgIdentifier = PgIdentifier ByteString
+newtype PgIdentifier = PgIdentifier ByteString deriving (Show)
 
 fromPgIdentifier :: PgIdentifier -> ByteString
 fromPgIdentifier (PgIdentifier bs) = bs

--- a/src/PostgRESTWS/HasqlBroadcast.hs
+++ b/src/PostgRESTWS/HasqlBroadcast.hs
@@ -84,8 +84,8 @@ newHasqlBroadcasterForConnection getCon = do
     forever $ do
       cmd <- atomically $ readTQueue cmds
       case cmd of
-        Open ch -> listen con ch
-        Close ch -> unlisten con ch
+        Open ch -> listen con $ toPgIdentifier ch
+        Close ch -> unlisten con $ toPgIdentifier ch
     ) (\_ -> hPutStrLn stderr "Broadcaster is dead")
   void $ relayMessagesForever multi
   return multi

--- a/test/DatabaseSpec.hs
+++ b/test/DatabaseSpec.hs
@@ -17,10 +17,10 @@ spec =
       notification <- liftIO newEmptyMVar
 
       waitForNotifications (curry $ putMVar notification) con
-      listen con "test"
+      listen con $ toPgIdentifier "test"
 
       conOrError2 <- H.acquire "postgres://localhost/postgrest_test"
       let con2 = either (panic . show) id conOrError2 :: H.Connection
-      void $ notify con2 "test" "hello there"
+      void $ notify con2 (toPgIdentifier "test") "hello there"
 
       readMVar notification `shouldReturn` ("test", "hello there")

--- a/test/HasqlBroadcastSpec.hs
+++ b/test/HasqlBroadcastSpec.hs
@@ -29,7 +29,7 @@ spec = describe "newHasqlBroadcaster" $ do
 
       atomically $ openChannelProducer multi "test"
 
-      let statement = H.statement "SELECT EXISTS (SELECT 1 FROM pg_stat_activity WHERE query ~* 'LISTEN \"test\"')"
+      let statement = H.statement "SELECT EXISTS (SELECT 1 FROM pg_stat_activity WHERE query ~* 'LISTEN \\\"test\\\"')"
                       HE.unit (HD.singleRow $ HD.value HD.bool) False
           query = H.query () statement
       booleanQueryShouldReturn con query True

--- a/test/HasqlBroadcastSpec.hs
+++ b/test/HasqlBroadcastSpec.hs
@@ -27,9 +27,10 @@ spec = describe "newHasqlBroadcaster" $ do
       con <- newConnection "postgres://localhost/postgrest_test"
       multi <- liftIO $ newHasqlBroadcaster "postgres://localhost/postgrest_test"
 
-      atomically $ openChannelProducer multi "test"
+      atomically $ openChannelProducer multi "test channel"
+      threadDelay 1000000
 
-      let statement = H.statement "SELECT EXISTS (SELECT 1 FROM pg_stat_activity WHERE query ~* 'LISTEN \\\"test\\\"')"
+      let statement = H.statement "SELECT EXISTS (SELECT 1 FROM pg_stat_activity WHERE query ~* 'LISTEN \\\"test channel\\\"')"
                       HE.unit (HD.singleRow $ HD.value HD.bool) False
           query = H.query () statement
       booleanQueryShouldReturn con query True
@@ -38,9 +39,10 @@ spec = describe "newHasqlBroadcaster" $ do
       con <- newConnection "postgres://localhost/postgrest_test"
       multi <- liftIO $ newHasqlBroadcaster "postgres://localhost/postgrest_test"
 
-      atomically $ closeChannelProducer multi "test"
+      atomically $ closeChannelProducer multi "test channel"
+      threadDelay 1000000
 
-      let statement = H.statement "SELECT EXISTS (SELECT 1 FROM pg_stat_activity WHERE query ~* 'UNLISTEN \"test\"')"
+      let statement = H.statement "SELECT EXISTS (SELECT 1 FROM pg_stat_activity WHERE query ~* 'UNLISTEN \\\"test channel\\\"')"
                       HE.unit (HD.singleRow $ HD.value HD.bool) False
           query = H.query () statement
       booleanQueryShouldReturn con query True


### PR DESCRIPTION
…annel names so we can ensure they are escaped properly.