### PR TITLE
Update stack LTS to 9.6

### DIFF
--- a/app/Config.hs
+++ b/app/Config.hs
@@ -28,7 +28,6 @@ import qualified Data.Configurator.Types     as C
 import           Data.Monoid
 import           Data.Text                   (intercalate, lines)
 import           Data.Text.Encoding          (encodeUtf8)
-import           Data.Text.IO                (hPutStrLn)
 import           Data.Version                (versionBranch)
 import           Options.Applicative hiding  (str)
 import           Paths_postgrest_ws             (version)
@@ -96,19 +95,15 @@ readOptions = do
   parserPrefs = prefs showHelpOnError
 
   configNotfoundHint :: IOError -> IO a
-  configNotfoundHint e = do
-    hPutStrLn stderr $
-      "Cannot open config file:\n\t" <> show e
-    exitFailure
+  configNotfoundHint e = die $ "Cannot open config file:\n\t" <> show e
 
   missingKeyHint :: C.KeyError -> IO a
-  missingKeyHint (C.KeyError n) = do
-    hPutStrLn stderr $
+  missingKeyHint (C.KeyError n) =
+    die $
       "Required config parameter \"" <> n <> "\" is missing or of wrong type.\n" <>
       "Documentation for configuration options available at\n" <>
       "\thttp://postgrest.com/en/v0.4/admin.html#configuration\n\n" <>
       "Try the --example-config option to see how to configure PostgREST."
-    exitFailure
 
   exampleCfg :: Doc
   exampleCfg = vsep . map (text . toS) . lines $

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,6 +1,6 @@
 module Main where
 
-import           Protolude
+import           Protolude hiding (replace)
 import           PostgRESTWS
 import           Config                               (AppConfig (..),
                                                        PgVersion (..),

--- a/postgrest-ws.cabal
+++ b/postgrest-ws.cabal
@@ -38,7 +38,7 @@ library
                      , unordered-containers >= 0.2
                      , postgresql-libpq >= 0.9 && < 1.0
                      , aeson >= 0.11
-                     , protolude >= 0.1.6 && < 0.2
+                     , protolude >= 0.2
                      , jwt >= 0.7.2 && < 0.8
                      , hasql >= 0.19
                      , either
@@ -64,7 +64,7 @@ executable postgrest-ws
                      , jwt >= 0.7 && < 1
                      , postgrest-ws
                      , postgresql-libpq >= 0.9 && < 1.0
-                     , protolude >= 0.1.6 && < 0.2
+                     , protolude >= 0.2
                      , base64-bytestring
                      , bytestring
                      , configurator
@@ -89,7 +89,7 @@ test-suite postgrest-ws-test
                      , DatabaseSpec
                      , HasqlBroadcastSpec
   build-depends:       base
-                     , protolude >= 0.1.6 && < 0.2
+                     , protolude >= 0.2
                      , postgrest-ws
                      , containers
                      , hspec

--- a/src/PostgRESTWS/Database.hs
+++ b/src/PostgRESTWS/Database.hs
@@ -10,7 +10,7 @@ module PostgRESTWS.Database
   , toPgIdentifier
   ) where
 
-import Protolude
+import Protolude hiding (replace)
 import Hasql.Pool (Pool, UsageError, use)
 import Hasql.Session (sql, run, query)
 import qualified Hasql.Session as S

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,3 @@
-resolver: lts-8.11
-extra-deps:
-  - hasql-pool-0.4.1
+resolver: lts-9.6
 ghc-options:
   postgrest-ws: -O2 -Wall -fwarn-identities -fno-warn-redundant-constraints


### PR DESCRIPTION
As a note I am using `nix` so I haven't been able to test this fully.

`hasql-pool` is indeed in  stack LTS-9.6:

https://www.stackage.org/lts-9.6/package/hasql-pool-0.4.1

`nix` is based on the latest LTS and everything compiles like a charm so I guess the change is pretty much safe.