### PR TITLE
Request channel in path

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,28 @@ After running the above command, open your browser on http://localhost:3000 to s
 The sample config file provided in the [sample.conf](https://github.com/diogob/postgrest-ws/tree/master/sample.conf) file comes with a jwt secret just for testing and is used in the sample client.
 You will find the complete sources for the example under the folder [client-example](https://github.com/diogob/postgrest-ws/tree/master/client-example).
 
+## Opening connections
+
+To open a websocket connection to the server there are two possible request formats.
+
+1. Requesting a channel and giving a token
+
+When you request access to a channel called `chat` the address of the websockets will look like:
+```
+ws://chat/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtb2RlIjoicncifQ.QKGnMJe41OFZcjz_qQSplmWAmVd_hmVjijKUNoJYpis
+```
+When the token contains a "channel" claim, the value of that claim has precedence over the requested channel.
+
+
+2. Giving only the token
+
+When you inform only the token on the websocket address, the channel must be present in the claims of your token. The address will look like:
+```
+ws://eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtb2RlIjoicnciLCJjaGFubmVsIjoiY2hhdCJ9.fEm6P7GHeJWZG8OtZhv3H0JdqPljE5dainvsoupM9pA
+```
+
+To use a secure socket (`wss://`) you will need a proxy server like nginx to handle the TLS layer. Some services (e.g. Heroku) will handle this automatially.
+
 ## Monitoring messages
 
 There is a way to receive a copy of every message sent from websocket clients to the server. This is useful in cases where one needs to audit the messages or persist then using an independent asynchronous process. To do so, one should enable a configuration called `audit-channel`. This option should be the name of a channel where all the messages sent from a websocket client will be replicated as an aditional NOTIFY command.

--- a/app/Config.hs
+++ b/app/Config.hs
@@ -31,7 +31,7 @@ import           Data.Version                (versionBranch)
 import           Options.Applicative hiding  (str)
 import           Paths_postgrest_ws             (version)
 import           Text.Heredoc
-import           Text.PrettyPrint.ANSI.Leijen hiding ((<>), (<$>))
+import           Text.PrettyPrint.ANSI.Leijen hiding ((<>))
 import qualified Text.PrettyPrint.ANSI.Leijen as L
 import           Protolude hiding            (intercalate, (<>))
 

--- a/client-example/client.js
+++ b/client-example/client.js
@@ -47,18 +47,16 @@ function sign(algorithm, header, payload, key) {
 }
 
 function updateJWT() {
-    var channel = $('#channel').val();
-    $('#jwt').val(jwtForChannel(channel));
+    $('#jwt').val(jwt());
 }
 
-function jwtForChannel(channel) {
+function jwt() {
     var alg = 'HS256',
         header = {
             alg: alg,
             typ: 'JWT'
         },
         payload = {
-            channel: channel,
             mode: 'rw'
         },
         key = 'auwhfdnskjhewfi34uwehdlaehsfkuaeiskjnfduierhfsiweskjcnzeiluwhskdewishdnpwe';
@@ -72,14 +70,15 @@ $(document).ready(function () {
     $('#channel').keyup(updateJWT);
     updateJWT();
 
-    auditWs = createWebSocket('/' + jwtForChannel('audit'));
+    auditWs = createWebSocket('/audit/' + jwt());
     auditWs.onmessage = onMessage('#audit-messages');
 
     $('#message-form').submit(function () {
         var text = $('#text').val();
         if(ws === null){
             var jwt = $('#jwt').val();
-            ws = createWebSocket('/' + jwt);
+            var channel = $('#channel').val();
+            ws = createWebSocket('/' + channel + '/' + jwt);
             ws.onopen = function() {
                 ws.send(text);
             };

--- a/client-example/index.html
+++ b/client-example/index.html
@@ -20,7 +20,7 @@
                     <br/>
                     <label for="jwt">JWT</label>
                     <br/>
-                    <textarea id="jwt" cols="50" rows="5" readonly="true"></textarea>
+                    <textarea id="jwt" cols="50" rows="5"></textarea>
                 </form>
             </div>
             <div id="chat-section">

--- a/postgrest-ws.cabal
+++ b/postgrest-ws.cabal
@@ -47,7 +47,7 @@ library
                      , time
                      , contravariant
   default-language:    Haskell2010
-  default-extensions: OverloadedStrings, NoImplicitPrelude
+  default-extensions: OverloadedStrings, NoImplicitPrelude, LambdaCase
 
 executable postgrest-ws
   hs-source-dirs:      app

--- a/postgrest-ws.cabal
+++ b/postgrest-ws.cabal
@@ -1,5 +1,5 @@
 name:                postgrest-ws
-version:             0.4.1.0
+version:             0.4.2.0
 synopsis:            PostgREST extension to map LISTEN/NOTIFY messages to Websockets
 description:         Please see README.md
 homepage:            https://github.com/diogob/postgrest-ws#readme

--- a/src/PostgRESTWS/Broadcast.hs
+++ b/src/PostgRESTWS/Broadcast.hs
@@ -107,10 +107,9 @@ onMessage multi chan action = do
         then M.insert Channel{ broadcast = broadcast c, listeners = listeners c - 1, close = close c} chan (channels multi)
         else closeChannelProducer multi chan
     openChannelWhenNotFound =
-      M.lookup chan (channels multi) >>= \mC ->
-      case mC of
-            Nothing -> openChannel multi chan
-            Just ch -> return ch
+      M.lookup chan (channels multi) >>= \case
+                                            Nothing -> openChannel multi chan
+                                            Just ch -> return ch
     addListener ch = do
       M.delete chan (channels multi)
       let newChannel = Channel{ broadcast = broadcast ch, listeners = listeners ch + 1, close = close ch}

--- a/test/ClaimsSpec.hs
+++ b/test/ClaimsSpec.hs
@@ -12,6 +12,6 @@ spec :: Spec
 spec =
   describe "validate claims"
   $ it "should succeed using a matching token"
-  $ validateClaims "reallyreallyreallyreallyverysafe"
+  $ validateClaims Nothing "reallyreallyreallyreallyverysafe"
                    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJtb2RlIjoiciIsImNoYW5uZWwiOiJ0ZXN0In0.1d4s-at2kWj8OSabHZHTbNh1dENF7NWy_r0ED3Rwf58"
                    `shouldReturn` Right ("test", "r", M.fromList[("mode",String "r"),("channel",String "test")])


### PR DESCRIPTION
Adds functionality to request channel using websocket path as suggested in #27 

When this gets merged a token that specifies no channel could be used to open an arbitrary channel defined by the caller on the URI of the websocket.